### PR TITLE
Altera versão do Django no requirements.txt

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2,7 +2,7 @@ argon2==0.1.10
 argon2-cffi==19.1.0
 cffi==1.12.3
 Click==7.0
-Django==2.2
+Django==2.2.2
 Jinja2==2.10.1
 livereload==2.6.1
 Markdown==3.1.1


### PR DESCRIPTION
Devido alertas de segurança, provenientes do próprio github, a versão do Django, no requirements.txt, foi alterada de 2.2 para 2.2.2